### PR TITLE
Sanitizing query parameter also

### DIFF
--- a/lib/procexss.js
+++ b/lib/procexss.js
@@ -56,9 +56,13 @@ module.exports = function procexss(options) {
 function processReq(req, part, options) {
     for (var prop in req[part]) {
         if (req[part].hasOwnProperty(prop)) {
-            var v = req[part][prop]
+            var v = req[part][prop];
+            if (options.regex.test(prop)) {
+                delete req[part][prop];
+                prop = sanitizer.sanitize(prop);
+            }
             if (options.regex.test(v)) {
-                req[part][prop] = sanitizer.sanitize(v)
+                req[part][prop] = sanitizer.sanitize(v);
             }
         }
     }


### PR DESCRIPTION
Right now, only query value is sanitized. XSS can be induced via query parameter also.

Example:
http://somesite.com?querykey%3C/script%3E%3Cscript%3Ealert%281%29%3C/script%3E=queryvalue%3C/script%3E%3Cscript%3Ealert%282%29%3C/script%3E
